### PR TITLE
updating updating com.android.support library

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    supportLibrary = '24.1.1'
+    supportLibrary = '24.2.0'
 
     espressoVersion = "2.2.2"
     testRunnerVersion = "0.5"
@@ -36,7 +36,7 @@ ext {
     ]
 
     playServicesDependencies = [
-            ads     : "com.google.android.gms:play-services-ads:${playServicesVersion}",
+            ads     : "com.google.firebase:firebase-ads:${playServicesVersion}",
             location: "com.google.android.gms:play-services-location:${playServicesVersion}",
             maps    : "com.google.android.gms:play-services-maps:${playServicesVersion}",
             auth    : "com.google.android.gms:play-services-auth:${playServicesVersion}"


### PR DESCRIPTION
Note: Release 24.2.0 removes support for Android 2.2 (API level 8) and lower. Classes and methods that exist only to serve those system versions are now marked as deprecated and should no longer be used. These deprecated classes and methods may be removed in a future release.

change admob to firebase