### PR TITLE
Update build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Project template for Android and demo app for tutorials on [michenux.net](http:/
 ## Requirements
 
 * Android SDK 24 (with extras/Google Repository)
-* Android Studio 2.1.3 (or later)
+* Android Studio 2.2 (or later)
 
 ## What you can find inside
 

--- a/YourAppIdea/build.gradle
+++ b/YourAppIdea/build.gradle
@@ -52,10 +52,6 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
-
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
 }
 
 dependencies {

--- a/YourAppIdea/build.gradle
+++ b/YourAppIdea/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "me.tatarka.retrolambda" version "3.2.5"
+    id "me.tatarka.retrolambda" version "3.3.0"
 }
 
 apply plugin: 'com.android.application'

--- a/YourAppIdea/lint.xml
+++ b/YourAppIdea/lint.xml
@@ -2,5 +2,7 @@
 <lint>
     <issue id="InvalidPackage">
         <ignore regexp=".*javapoet.*"/>
+        <ignore regexp=".*okio.*"/>
+        <ignore regexp=".*retrofit.*"/>
     </issue>
 </lint>

--- a/YourAppIdea/src/main/java/org/michenux/yourappidea/aroundme/AroundMeFragment.java
+++ b/YourAppIdea/src/main/java/org/michenux/yourappidea/aroundme/AroundMeFragment.java
@@ -1,6 +1,7 @@
 package org.michenux.yourappidea.aroundme;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.location.Address;
@@ -222,6 +223,7 @@ public class AroundMeFragment extends Fragment implements
         registerLocationUpdates();
     }
 
+    @SuppressLint("MissingPermission") // Permissions enforced through RxPermissions
     private void registerLocationUpdates() {
         PendingResult<Status> result = LocationServices.FusedLocationApi
                 .requestLocationUpdates(

--- a/YourAppIdea/src/main/res/values/strings_aroundme.xml
+++ b/YourAppIdea/src/main/res/values/strings_aroundme.xml
@@ -5,7 +5,7 @@
     <string name="cities_contentprovider_authority">org.michenux.yourappidea.cities</string>
 
     <string name="aroundme_nolocation">Waiting for location updates...</string>
-    <string name="aroundme_placedistance">%1$s km</string>
+    <string name="aroundme_placedistance">%1$d km</string>
     <string name="aroundme_placeremoteprovider_url">https://api.mongolab.com/</string>
     <string name="cityactivity_title">Select city...</string>
     <string name="aroundme_info_title">Info</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
     mockitoVersion = "1.10.19"
     hamcrestVersion = "1.3"
 
-    playServicesVersion = "9.4.0"
+    playServicesVersion = "9.6.0"
 
     gsonVersion = "2.7"
     okhttpVersion = "3.4.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 02 15:59:42 SGT 2016
+#Wed Sep 21 14:45:53 IST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip


### PR DESCRIPTION
Supersedes #31

I cherry-picked cef4586fc1c0a774fc368af548ede481b103fcbd from @wendersonferreira (and renamed the message according to http://chris.beams.io/posts/git-commit/) to update the Android Gradle plugin to `2.2.0`. Regarding the updated Lint checks: There is no need to call `checkSelfPermission` - permissions are already enforced through RxPermissions.

This PR also include various other minor updates. E.g. Gradle wrapper 3.1 which massively speed up project compilation time.